### PR TITLE
Remove use of ::shadow, deprecated in Atom v1.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ The `cursorLineFix` is currently ignored due to the new tile rendering of the ed
 
 You can also add this to your `styles.less` to disable the line highlight:
 ```less
-atom-text-editor::shadow .lines .line.cursor-line {
+atom-text-editor.editor .lines .line.cursor-line {
   background-color: transparent;
 }
 ```

--- a/lib/block-cursor.js
+++ b/lib/block-cursor.js
@@ -153,7 +153,7 @@ function selectorForScopes(base, scopes, blinkOff = '') {
 
   for(let scopeName of scopes) {
     let grammarSelectors = scopeName == '*' ? '' : grammarSelectorsForScopeName(scopeName);
-    selectors.push(`${base}${grammarSelectors}::shadow .cursors${blinkOff} .cursor`);
+    selectors.push(`${base}${grammarSelectors}.editor .cursors${blinkOff} .cursor`);
   }
   return selectors.join(',');
 }

--- a/styles/block-cursor.less
+++ b/styles/block-cursor.less
@@ -1,4 +1,4 @@
-atom-text-editor::shadow .cursors .cursor {
+atom-text-editor.editor .cursors .cursor {
   opacity: 1;
   color: transparent;
   background-color: transparent;
@@ -6,6 +6,6 @@ atom-text-editor::shadow .cursors .cursor {
   transition-property: background-color, border-color, opacity;
 }
 
-atom-text-editor[mini]:not(.is-focused)::shadow .cursors .cursor {
+atom-text-editor[mini]:not(.is-focused).editor .cursors .cursor {
   display: none;
 }


### PR DESCRIPTION
Resolves https://github.com/olmokramer/atom-block-cursor/issues/33